### PR TITLE
Improve formatting of external event wall entries

### DIFF
--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -37,11 +37,13 @@ if($description) {
                     data-read-more-text="<?= Yii::t('ExternalCalendarModule.widgets', "Read full description...") ?>"
                     style="overflow:hidden">
 
-                <?= $description ?>
+                <p><?= $description ?></p>
 
                 <?php if (!empty($calendarEntry->location)) : ?>
-                    <i class="fa fa-map-marker colorDefault pull-left" style="font-size: 20px; margin-right: 8px"></i>
-                    <?= Html::encode( $calendarEntry->location) ?>
+                    <p>
+                        <i class="fa fa-map-marker colorDefault pull-left" style="font-size: 20px; margin-right: 8px"></i>
+                        <?= Html::encode( $calendarEntry->location) ?>
+                    </p>
                 <?php endif; ?>
             </div>
         <?php endif; ?>


### PR DESCRIPTION
The location details of external events (and icon) were getting mixed
with the description. Improve this by placing the description and
location in separate paragraphs.