### PR TITLE
Rename "Event" content type to "External Event"

### DIFF
--- a/messages/am/base.php
+++ b/messages/am/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/an/base.php
+++ b/messages/an/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/ar/base.php
+++ b/messages/ar/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/bg/base.php
+++ b/messages/bg/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/br/base.php
+++ b/messages/br/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/ca/base.php
+++ b/messages/ca/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'L\'hora final ha de ser després de l\'hora d\'inici!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Esdeveniment',
+  'External Event' => 'Esdeveniment',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/cs/base.php
+++ b/messages/cs/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Datum konce události musí následovat po začátku!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Událost',
+  'External Event' => 'Událost',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/da/base.php
+++ b/messages/da/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Slut tidspunkt skal være efter start tidspunkt!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Event',
+  'External Event' => 'Event',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/de/base.php
+++ b/messages/de/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Das Ende muss nach dem Start liegen!',
   'Error creating event in ical synchronization' => 'Fehler beim erstellen eines Events in der ICal Synchronisation',
   'Error while synchronizing recurring ical event' => 'Fehler beim synochronisieren eines wiederkehrenden iCal-Events',
-  'Event' => 'Termin',
+  'External Event' => 'Termin',
   'Extends the Calendar-Module to show external calendars with iCal' => 'Erweitert das Kalender-Modul, um externe Kalender im iCal-Format zu integrieren.',
   'External Calendar' => 'Externer Kalender',
   'External Calendar Entry' => 'Externer Kalendereintrag',

--- a/messages/el/base.php
+++ b/messages/el/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Η ώρα λήξης πρέπει να είναι μετά το χρόνο έναρξης!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Εκδήλωση',
+  'External Event' => 'Εκδήλωση',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/es/base.php
+++ b/messages/es/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '¡La fecha de fin tiene que ser después de la fecha de inicio!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Evento',
+  'External Event' => 'Evento',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/fa-IR/base.php
+++ b/messages/fa-IR/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'تاریخ پایان باید پس از تاریخ آغاز باشد!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'رویداد',
+  'External Event' => 'رویداد',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/fa_ir/base.php
+++ b/messages/fa_ir/base.php
@@ -11,7 +11,7 @@ return [
     'Download as ICS file' => '',
     'Edit' => '',
     'End time must be after start time!' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/fi/base.php
+++ b/messages/fi/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Päättymisaika on oltava alkamisajan jälkeen!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Tapahtuma',
+  'External Event' => 'Tapahtuma',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/fr/base.php
+++ b/messages/fr/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'L\'heure de fin doit être après l\'heure de départ.',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Événement',
+  'External Event' => 'Événement',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/he/base.php
+++ b/messages/he/base.php
@@ -16,7 +16,7 @@ return [
     'End time must be after start time!' => '',
     'Error creating event in ical synchronization' => '',
     'Error while synchronizing recurring ical event' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/hr/base.php
+++ b/messages/hr/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Vrijeme završetka mora biti nakon vremena početka!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Događaj',
+  'External Event' => 'Događaj',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/ht/base.php
+++ b/messages/ht/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/hu/base.php
+++ b/messages/hu/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'A befejezés időpontjának a kezdés időpontja utáni időpontnak kell lennie!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Esemény',
+  'External Event' => 'Esemény',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/id/base.php
+++ b/messages/id/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'waktu akhir harus setelah waktu mulai !!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Acara',
+  'External Event' => 'Acara',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/it/base.php
+++ b/messages/it/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'L\'ora di fine deve essere successiva all\'ora di inizio! ',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Evento',
+  'External Event' => 'Evento',
   'Extends the Calendar-Module to show external calendars with iCal' => 'Estende il modulo del calendario per mostrare calendari esterni via iCal',
   'External Calendar' => 'Calendario esterno',
   'External Calendar Entry' => 'Annotazione calendario esterno',

--- a/messages/ja/base.php
+++ b/messages/ja/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '終了時刻は開始時刻より後になるように設定してください！',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'イベント',
+  'External Event' => 'イベント',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/ko/base.php
+++ b/messages/ko/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/lt/base.php
+++ b/messages/lt/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Pabaigos laikas turi būti po pradžios laiko!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Įvykis',
+  'External Event' => 'Įvykis',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/lv/base.php
+++ b/messages/lv/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Beigu laikam ir jābūt pēc sākuma laika!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Notikums',
+  'External Event' => 'Notikums',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/nb-NO/base.php
+++ b/messages/nb-NO/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Aktiviteten kan ikke slutte før den har startet!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Aktiviteten',
+  'External Event' => 'Aktiviteten',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/nb_no/base.php
+++ b/messages/nb_no/base.php
@@ -11,7 +11,7 @@ return [
     'Download as ICS file' => '',
     'Edit' => '',
     'End time must be after start time!' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/nl/base.php
+++ b/messages/nl/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Eindtijd moet na de starttijd liggen!',
   'Error creating event in ical synchronization' => 'Fout bij ical-synchronisatie van een nieuwe gebeurtenis',
   'Error while synchronizing recurring ical event' => 'Fout bij ical-synchronisatie van een herhalende gebeurtenis',
-  'Event' => 'Gebeurtenis',
+  'External Event' => 'Gebeurtenis',
   'Extends the Calendar-Module to show external calendars with iCal' => 'Breidt de agendamodule uit om externe agenda\\\'s te tonen met iCal',
   'External Calendar' => 'Externe agenda',
   'External Calendar Entry' => 'Externe agenda-invoer',

--- a/messages/nn-NO/base.php
+++ b/messages/nn-NO/base.php
@@ -16,7 +16,7 @@ return [
     'End time must be after start time!' => '',
     'Error creating event in ical synchronization' => '',
     'Error while synchronizing recurring ical event' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/nn_no/base.php
+++ b/messages/nn_no/base.php
@@ -11,7 +11,7 @@ return [
     'Download as ICS file' => '',
     'Edit' => '',
     'End time must be after start time!' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/pl/base.php
+++ b/messages/pl/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Zacz zakończenia musi być po czasie rozpoczęcia!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Wydarzenie',
+  'External Event' => 'Wydarzenie',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/pt-BR/base.php
+++ b/messages/pt-BR/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'A hora de término precisa ser depois da hora de início!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Evento',
+  'External Event' => 'Evento',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/pt/base.php
+++ b/messages/pt/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Horário final precisa ser depois do horário inicial.',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Evento',
+  'External Event' => 'Evento',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/pt_br/base.php
+++ b/messages/pt_br/base.php
@@ -11,7 +11,7 @@ return [
     'Download as ICS file' => '',
     'Edit' => '',
     'End time must be after start time!' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/ro/base.php
+++ b/messages/ro/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Timpul scadent trebuie să fie după timpul de început!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Eveniment',
+  'External Event' => 'Eveniment',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/ru/base.php
+++ b/messages/ru/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Время окончания должно быть позже начала',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Событие',
+  'External Event' => 'Событие',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/sk/base.php
+++ b/messages/sk/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/sl/base.php
+++ b/messages/sl/base.php
@@ -16,7 +16,7 @@ return [
     'End time must be after start time!' => '',
     'Error creating event in ical synchronization' => '',
     'Error while synchronizing recurring ical event' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/sv/base.php
+++ b/messages/sv/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Sluttid måste vara efter starttid!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Aktivitet',
+  'External Event' => 'Aktivitet',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/th/base.php
+++ b/messages/th/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '',
+  'External Event' => '',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/tr/base.php
+++ b/messages/tr/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Bitiş saati başlangıç ​​zamanından sonra olmalıdır!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Etkinlik',
+  'External Event' => 'Etkinlik',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/uk/base.php
+++ b/messages/uk/base.php
@@ -16,7 +16,7 @@ return [
     'End time must be after start time!' => '',
     'Error creating event in ical synchronization' => '',
     'Error while synchronizing recurring ical event' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/uz/base.php
+++ b/messages/uz/base.php
@@ -16,7 +16,7 @@ return [
     'End time must be after start time!' => '',
     'Error creating event in ical synchronization' => '',
     'Error while synchronizing recurring ical event' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/vi/base.php
+++ b/messages/vi/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => 'Ngày kết thúc phải sau ngày bắt đầu!',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => 'Sự kiện',
+  'External Event' => 'Sự kiện',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/zh-CN/base.php
+++ b/messages/zh-CN/base.php
@@ -15,7 +15,7 @@ return array (
   'End time must be after start time!' => '结束时间必须晚于开始时间！',
   'Error creating event in ical synchronization' => '',
   'Error while synchronizing recurring ical event' => '',
-  'Event' => '事件',
+  'External Event' => '事件',
   'Extends the Calendar-Module to show external calendars with iCal' => '',
   'External Calendar' => '',
   'External Calendar Entry' => '',

--- a/messages/zh-TW/base.php
+++ b/messages/zh-TW/base.php
@@ -16,7 +16,7 @@ return [
     'End time must be after start time!' => '',
     'Error creating event in ical synchronization' => '',
     'Error while synchronizing recurring ical event' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/zh_cn/base.php
+++ b/messages/zh_cn/base.php
@@ -11,7 +11,7 @@ return [
     'Download as ICS file' => '',
     'Edit' => '',
     'End time must be after start time!' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/messages/zh_tw/base.php
+++ b/messages/zh_tw/base.php
@@ -11,7 +11,7 @@ return [
     'Download as ICS file' => '',
     'Edit' => '',
     'End time must be after start time!' => '',
-    'Event' => '',
+    'External Event' => '',
     'Extends the Calendar-Module to show external calendars with iCal' => '',
     'External Calendar' => '',
     'External Calendar Entry' => '',

--- a/models/ExternalCalendarEntry.php
+++ b/models/ExternalCalendarEntry.php
@@ -99,7 +99,7 @@ class ExternalCalendarEntry extends ContentActiveRecord implements Searchable
      */
     public function getContentName()
     {
-        return Yii::t('ExternalCalendarModule.base', "Event");
+        return Yii::t('ExternalCalendarModule.base', "External Event");
     }
 
     /**


### PR DESCRIPTION
The "Event" content type is already in use for calendar events, and
using the same content name for external calendar events is confusing
when the content types are shown in a list, for example when filtering
by content type. Avoid this by using the content type "External Event"
instead.