### PR TITLE
Fix external calendar sync on unmodified events

### DIFF
--- a/models/ICalSync.php
+++ b/models/ICalSync.php
@@ -173,8 +173,10 @@ class ICalSync extends Model
             }
 
             foreach ($existingModelsInRange as $index => $model) {
-                if ($model->uid === $icalEvent->getUid() && $model->wasModifiedSince($icalEvent)) {
-                    $model->syncWithICal($icalEvent, $this->calendarModel->time_zone);
+                if ($model->uid === $icalEvent->getUid()) {
+                    if ($model->wasModifiedSince($icalEvent)) {
+                        $model->syncWithICal($icalEvent, $this->calendarModel->time_zone);
+                    }
                     unset($icalEventsInRange[$eventKey], $existingModelsInRange[$index]);
                     break;
                 }


### PR DESCRIPTION
When syncing external calendars, unmodified events resulted in posting
new events to the top of the stream, and the old events being deleted.

Fix this so as not to create new events for existing calendar entries.

(This properly fixes issue #7.)