### PR TITLE
Fix external event end times

### DIFF
--- a/models/ICalFileEvent.php
+++ b/models/ICalFileEvent.php
@@ -139,7 +139,7 @@ class ICalFileEvent extends Event implements ICalEventIF
         }
 
         if(!$result) {
-            $result =  (new DateTime())->setTimestamp($this->dtstart_array[2]);
+            $result = (new DateTime())->setTimestamp($dtArr[2]);
         }
 
         return $result;


### PR DESCRIPTION
External events were having their end times set the same as their start
times.