### PR TITLE
getEndDateTime: Use consistent capitalization

### DIFF
--- a/models/ExternalCalendarEntry.php
+++ b/models/ExternalCalendarEntry.php
@@ -481,7 +481,7 @@ class ExternalCalendarEntry extends ContentActiveRecord implements Searchable
         $this->last_modified = CalendarUtils::toDBDateFormat($icalEvent->getLastModified());
         $this->dtstamp = CalendarUtils::toDBDateFormat($icalEvent->getTimeStamp());
         $this->start_datetime = CalendarUtils::toDBDateformat($icalEvent->getStartDateTime());
-        $this->end_datetime = CalendarUtils::toDBDateFormat($icalEvent->getEndDaTetime());
+        $this->end_datetime = CalendarUtils::toDBDateFormat($icalEvent->getEndDateTime());
         $this->exdate = $icalEvent->getExdate();
 
         if ($timeZone) {

--- a/models/ICalFileEvent.php
+++ b/models/ICalFileEvent.php
@@ -82,13 +82,13 @@ class ICalFileEvent extends Event implements ICalEventIF
     public function isAllDay()
     {
         // If one of dtstart or dtend has actual time value this can't be an all day event
-        if($this->getStartDateTime()->format('H:i:s') !== '00:00:00' || $this->getEndDaTetime()->format('H:i:s') !== '00:00:00') {
+        if($this->getStartDateTime()->format('H:i:s') !== '00:00:00' || $this->getEndDateTime()->format('H:i:s') !== '00:00:00') {
             return false;
         }
 
 
         // If dtstart has a date time value (even if 00:00:00) dtend must not be euqal to dtstart
-        return $this->isDateOnlyFormat($this->dtstart) || ($this->getEndDatetime() > $this->getStartDateTime());
+        return $this->isDateOnlyFormat($this->dtstart) || ($this->getEndDateTime() > $this->getStartDateTime());
     }
 
     /**
@@ -132,7 +132,7 @@ class ICalFileEvent extends Event implements ICalEventIF
 
     private function getDateTimeFromDTArray($dtArr)
     {
-        $result = nulL;
+        $result = null;
         // We need this since the ICal parser does not ignore timezone values for DATE only values
         if(isset($dtArr[0]['VALUE']) && $dtArr[0]['VALUE'] === 'DATE' || strlen($dtArr[1]) === 8)  {
             $result = DateTime::createFromFormat(CalendarUtils::ICAL_DATE_FORMAT, $dtArr[1])->setTime(0,0,0);
@@ -149,7 +149,7 @@ class ICalFileEvent extends Event implements ICalEventIF
      * @return \DateTime
      * @throws \Exception
      */
-    public function getEndDatetime()
+    public function getEndDateTime()
     {
         if($this->endDateTime) {
             return $this->endDateTime;


### PR DESCRIPTION
The getEndDateTime() method and NULL value were referenced using
inconsistent capitalization.

As PHP is not case-sensitive in these names, this change is purely
cosmetic.